### PR TITLE
Avoid error on mapcar when elements aren't a list.

### DIFF
--- a/ghub+.el
+++ b/ghub+.el
@@ -41,8 +41,10 @@
   (defun ghubp--stringify-params (params)
     "Process PARAMS from textual data to Lisp structures."
     (mapcar (lambda (p)
-              (let ((k (car p)) (v (cdr p)))
-                (cons k (alist-get v '((t . "true") (nil . "false")) v))))
+              (if (listp p)
+		  (let ((k (car p)) (v (cdr p)))
+		    (cons k (alist-get v '((t . "true") (nil . "false")) v)))
+		p))
             params))
 
   (defun ghubp--pre-process-params (params)


### PR DESCRIPTION
Avoid error when called by magithub:
```
Debugger entered--Lisp error: (wrong-type-argument listp :head)
  car(:head)
  (let ((k (car p)) (v (cdr p))) (cons k (alist-get v (quote ((t . "true") (nil . "false"))) v)))
  (closure ((params :head "origin:master") t) (p) (let ((k (car p)) (v (cdr p))) (cons k (alist-get v (quote ((t . "true") (nil . "false"))) v))))(:head)
  mapcar((closure ((params :head "origin:master") t) (p) (let ((k (car p)) (v (cdr p))) (cons k (alist-get v (quote ((t . "true") (nil . "false"))) v)))) (:head "origin:master"))
  ghubp--stringify-params((:head "origin:master"))
  ghubp--pre-process-params((:head "origin:master"))
  (list (ghubp--pre-process-params (cons data params)) nil)
  (if (keywordp data) (list (ghubp--pre-process-params (cons data params)) nil) (list (ghubp--pre-process-params params) data))
  (apply (function ghubp-request) (quote get) (let ((alist (list (cons (quote repo) repo)))) (let ((\.repo\.owner\.login (cdr (assq (quote login) (cdr ...)))) (\.repo\.name (cdr (assq (quote name) (cdr ...))))) (format "/repos/%s/%s/pulls" (apiwrap--encode-url \.repo\.owner\.login) (apiwrap--encode-url \.repo\.name)))) (if (keywordp data) (list (ghubp--pre-process-params (cons data params)) nil) (list (ghubp--pre-process-params params) data)))
  ghubp-get-repos-owner-repo-pulls(((id . 82884749) (name . "ghub-plus") (full_name . "vermiculus/ghub-plus") (owner (login . "vermiculus") (id . 2082195) (avatar_url . "https://avatars3.githubusercontent.com/u/2082195?v=4") (gravatar_id . "") (url . "https://api.github.com/users/vermiculus") (html_url . "https://github.com/vermiculus") (followers_url . "https://api.github.com/users/vermiculus/followers") (following_url . "https://api.github.com/users/vermiculus/following{/other_user}") (gists_url . "https://api.github.com/users/vermiculus/gists{/gist_id}") (starred_url . "https://api.github.com/users/vermiculus/starred{/owner}{/repo}") (subscriptions_url . "https://api.github.com/users/vermiculus/subscriptions") (organizations_url . "https://api.github.com/users/vermiculus/orgs") (repos_url . "https://api.github.com/users/vermiculus/repos") (events_url . "https://api.github.com/users/vermiculus/events{/privacy}") (received_events_url . "https://api.github.com/users/vermiculus/received_events") (type . "User") (site_admin)) (private) (html_url . "https://github.com/vermiculus/ghub-plus") (description . "Wrappers for GitHub API resources built on ghub") (fork) (url . "https://api.github.com/repos/vermiculus/ghub-plus") (forks_url . "https://api.github.com/repos/vermiculus/ghub-plus/forks") (keys_url . "https://api.github.com/repos/vermiculus/ghub-plus/keys{/key_id}") (collaborators_url . "https://api.github.com/repos/vermiculus/ghub-plus/collaborators{/collaborator}") (teams_url . "https://api.github.com/repos/vermiculus/ghub-plus/teams") (hooks_url . "https://api.github.com/repos/vermiculus/ghub-plus/hooks") (issue_events_url . "https://api.github.com/repos/vermiculus/ghub-plus/issues/events{/number}") (events_url . "https://api.github.com/repos/vermiculus/ghub-plus/events") (assignees_url . "https://api.github.com/repos/vermiculus/ghub-plus/assignees{/user}") (branches_url . "https://api.github.com/repos/vermiculus/ghub-plus/branches{/branch}") (tags_url . "https://api.github.com/repos/vermiculus/ghub-plus/tags") (blobs_url . "https://api.github.com/repos/vermiculus/ghub-plus/git/blobs{/sha}") (git_tags_url . "https://api.github.com/repos/vermiculus/ghub-plus/git/tags{/sha}") (git_refs_url . "https://api.github.com/repos/vermiculus/ghub-plus/git/refs{/sha}") (trees_url . "https://api.github.com/repos/vermiculus/ghub-plus/git/trees{/sha}") (statuses_url . "https://api.github.com/repos/vermiculus/ghub-plus/statuses/{sha}") (languages_url . "https://api.github.com/repos/vermiculus/ghub-plus/languages") (stargazers_url . "https://api.github.com/repos/vermiculus/ghub-plus/stargazers") (contributors_url . "https://api.github.com/repos/vermiculus/ghub-plus/contributors") (subscribers_url . "https://api.github.com/repos/vermiculus/ghub-plus/subscribers") (subscription_url . "https://api.github.com/repos/vermiculus/ghub-plus/subscription") (commits_url . "https://api.github.com/repos/vermiculus/ghub-plus/commits{/sha}") (git_commits_url . "https://api.github.com/repos/vermiculus/ghub-plus/git/commits{/sha}") (comments_url . "https://api.github.com/repos/vermiculus/ghub-plus/comments{/number}") (issue_comment_url . "https://api.github.com/repos/vermiculus/ghub-plus/issues/comments{/number}") (contents_url . "https://api.github.com/repos/vermiculus/ghub-plus/contents/{+path}") (compare_url . "https://api.github.com/repos/vermiculus/ghub-plus/compare/{base}...{head}") (merges_url . "https://api.github.com/repos/vermiculus/ghub-plus/merges") (archive_url . "https://api.github.com/repos/vermiculus/ghub-plus/{archive_format}{/ref}") (downloads_url . "https://api.github.com/repos/vermiculus/ghub-plus/downloads") (issues_url . "https://api.github.com/repos/vermiculus/ghub-plus/issues{/number}") (pulls_url . "https://api.github.com/repos/vermiculus/ghub-plus/pulls{/number}") (milestones_url . "https://api.github.com/repos/vermiculus/ghub-plus/milestones{/number}") (notifications_url . "https://api.github.com/repos/vermiculus/ghub-plus/notifications{?since,all,participating}") (labels_url . "https://api.github.com/repos/vermiculus/ghub-plus/labels{/name}") (releases_url . "https://api.github.com/repos/vermiculus/ghub-plus/releases{/id}") (deployments_url . "https://api.github.com/repos/vermiculus/ghub-plus/deployments") (created_at . "2017-02-23T04:38:17Z") (updated_at . "2017-08-27T22:49:32Z") (pushed_at . "2017-10-17T01:52:10Z") (git_url . "git://github.com/vermiculus/ghub-plus.git") (ssh_url . "git@github.com:vermiculus/ghub-plus.git") ...) :head "origin:master")
  magithub-pull-request-branch->pr("master")
  magithub-ci-status--get-default-ref()
  magithub-insert-ci-status-header()
  magithub-maybe-insert-ci-status-header()
  funcall(magithub-maybe-insert-ci-status-header)
  mapc(funcall (magit-insert-error-header magit-insert-diff-filter-header magit-insert-head-branch-header magit-insert-upstream-branch-header magit-insert-push-branch-header magit-insert-tags-header magithub-maybe-insert-ci-status-header))
  magit-insert-remaining-headers()
  run-hooks(magit-insert-section-hook)
  magithub-maybe-report-offline-mode()
  magit-insert-headers((magithub-maybe-report-offline-mode magit-insert-error-header magit-insert-diff-filter-header magit-insert-head-branch-header magit-insert-upstream-branch-header magit-insert-push-branch-header magit-insert-tags-header magithub-maybe-insert-ci-status-header))
  magit-insert-status-headers()
  run-hooks(magit-status-sections-hook)
  magit-run-section-hook(magit-status-sections-hook)
  magit-status-refresh-buffer()
  apply(magit-status-refresh-buffer nil)
  magit-refresh-buffer()
  magit-refresh()
  magithub-refresh(nil)
  funcall-interactively(magithub-refresh nil)
  call-interactively(magithub-refresh)
  magit-invoke-popup-action(103)
  funcall-interactively(magit-invoke-popup-action 103)
  call-interactively(magit-invoke-popup-action nil nil)
  command-execute(magit-invoke-popup-action)
```