### PR TITLE
Fix sending multibyte responses

### DIFF
--- a/ghub+.el
+++ b/ghub+.el
@@ -104,7 +104,7 @@ PARAMS is a plist.
 
 DATA is an alist."
     (let-alist (ghubp-get-context)
-      (let ((method (upcase (symbol-name method)))
+      (let ((method (encode-coding-string (upcase (symbol-name method)) 'utf-8))
             (params (apiwrap-plist->alist params)))
         (funcall (or ghubp-request-override-function
                      #'ghub-request)


### PR DESCRIPTION
Turns out that `(symbol-name 'sym)` is a multibyte string; pass through `encode-coding-string` before handing it off to Ghub/`url`.

Related to magit/ghub#35.