### PR TITLE
Fix: require subr-x (needed for if-let)

### DIFF
--- a/ghub+.el
+++ b/ghub+.el
@@ -30,6 +30,7 @@
 
 (require 'url)
 (require 'cl-lib)
+(require 'subr-x)
 (require 'ghub)
 (require 'apiwrap)
 


### PR DESCRIPTION
Its absence results in a compile error when using borg-build:

    In ghubp-base-html-url: ghub+.el:300:8:Warning: ‘(host (car (ignore-errors (process-lines "git" "config" "github.host"))))’ is a malformed function ghub+.el:304:65:Warning: reference to free variable ‘host’

    In end of data: ghub+.el:1085:1:Warning: the function ‘if-let’ is not known to be defined.