### PR TITLE
fix failure with recent versions of ghub

### DIFF
--- a/ghub+.el
+++ b/ghub+.el
@@ -311,7 +311,7 @@ See that documentation for RESOURCE, PARAMS, and DATA."
 
 (defun ghubp-username ()
   "Exposes `ghub--username'."
-  (ghub--username (ghub--host)))
+  (ghub--username (ghub--host 'github)))
 
 (defun ghubp-token (package)
   "Exposes `ghub--token' for PACKAGE in a friendly way."


### PR DESCRIPTION
for reasons I don't quite understand, the call to `ghub--host` fails for me without a parameter, even though the `forge` parameter is meant to be optional.  This tiny change fixes the issue for me.